### PR TITLE
SDK-1625: Doc Scan sandbox error message

### DIFF
--- a/lib/yoti_sandbox/doc_scan.rb
+++ b/lib/yoti_sandbox/doc_scan.rb
@@ -1,6 +1,7 @@
 require 'yoti'
 
 require_relative 'doc_scan/client'
+require_relative 'doc_scan/errors'
 require_relative 'doc_scan/request/task_results'
 require_relative 'doc_scan/request/check_reports'
 require_relative 'doc_scan/request/response_config'

--- a/lib/yoti_sandbox/doc_scan/client.rb
+++ b/lib/yoti_sandbox/doc_scan/client.rb
@@ -19,29 +19,39 @@ module Yoti
         # @param [Yoti::SandboxDocScan::Request::ResponseConfig] response_config
         #
         def configure_session_response(session_id, response_config)
-          Yoti::Request
-            .builder
-            .with_http_method('PUT')
-            .with_base_url(@base_url)
-            .with_endpoint("sessions/#{session_id}/response-config")
-            .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
-            .with_payload(response_config)
-            .build
-            .execute
+          request = Yoti::Request
+                    .builder
+                    .with_http_method('PUT')
+                    .with_base_url(@base_url)
+                    .with_endpoint("sessions/#{session_id}/response-config")
+                    .with_query_param('sdkId', Yoti.configuration.client_sdk_id)
+                    .with_payload(response_config)
+                    .build
+
+          begin
+            request.execute
+          rescue Yoti::RequestError => e
+            raise Yoti::Sandbox::DocScan::Error.wrap(e)
+          end
         end
 
         #
         # @param [Yoti::SandboxDocScan::Request::ResponseConfig] response_config
         #
         def configure_application_response(response_config)
-          Yoti::Request
-            .builder
-            .with_http_method('PUT')
-            .with_base_url(@base_url)
-            .with_endpoint("apps/#{Yoti.configuration.client_sdk_id}/response-config")
-            .with_payload(response_config)
-            .build
-            .execute
+          request = Yoti::Request
+                    .builder
+                    .with_http_method('PUT')
+                    .with_base_url(@base_url)
+                    .with_endpoint("apps/#{Yoti.configuration.client_sdk_id}/response-config")
+                    .with_payload(response_config)
+                    .build
+
+          begin
+            request.execute
+          rescue Yoti::RequestError => e
+            raise Yoti::Sandbox::DocScan::Error.wrap(e)
+          end
         end
       end
     end

--- a/lib/yoti_sandbox/doc_scan/errors.rb
+++ b/lib/yoti_sandbox/doc_scan/errors.rb
@@ -1,0 +1,83 @@
+require 'json'
+
+module Yoti
+  module Sandbox
+    module DocScan
+      #
+      # Raises exceptions related to Doc Scan Sandbox API requests
+      #
+      class Error < RequestError
+        def initialize(msg = nil, response = nil)
+          super(msg, response)
+
+          @default_message = msg
+        end
+
+        def message
+          @message ||= format_message
+        end
+
+        #
+        # Wraps an existing error
+        #
+        # @param [Error] error
+        #
+        # @return [self]
+        #
+        def self.wrap(error)
+          new(error.message, error.response)
+        end
+
+        private
+
+        #
+        # Formats error message from response.
+        #
+        # @return [String]
+        #
+        def format_message
+          return @default_message if @response.nil? || @response['Content-Type'] != 'application/json'
+
+          json = JSON.parse(@response.body)
+          format_response(json) || @default_message
+        end
+
+        #
+        # Format JSON error response.
+        #
+        # @param [Hash] json
+        #
+        # @return [String, nil]
+        #
+        def format_response(json)
+          return nil if json['code'].nil? || json['message'].nil?
+
+          code_message = "#{json['code']} - #{json['message']}"
+
+          unless json['errors'].nil?
+            property_errors = format_property_errors(json['errors'])
+
+            return "#{code_message}: #{property_errors.compact.join(', ')}" if property_errors.count.positive?
+          end
+
+          code_message
+        end
+
+        #
+        # Format property errors.
+        #
+        # @param [Array<Hash>] errors
+        #
+        # @return [Array<String>]
+        #
+        def format_property_errors(errors)
+          errors
+            .map do |e|
+              "#{e['property']} \"#{e['message']}\"" if e['property'] && e['message']
+            end
+            .compact
+        end
+      end
+    end
+  end
+end

--- a/spec/yoti_sandbox/doc_scan/client_spec.rb
+++ b/spec/yoti_sandbox/doc_scan/client_spec.rb
@@ -57,7 +57,7 @@ describe 'Yoti::Sandbox::DocScan::Client' do
 
       it 'raises an error' do
         expect { client.configure_session_response(some_session_id, some_response_config) }
-          .to raise_error Yoti::RequestError
+          .to raise_error Yoti::Sandbox::DocScan::Error
       end
     end
   end
@@ -92,7 +92,7 @@ describe 'Yoti::Sandbox::DocScan::Client' do
 
       it 'raises an error' do
         expect { client.configure_application_response(some_response_config) }
-          .to raise_error Yoti::RequestError
+          .to raise_error Yoti::Sandbox::DocScan::Error
       end
     end
   end

--- a/spec/yoti_sandbox/doc_scan/errors_spec.rb
+++ b/spec/yoti_sandbox/doc_scan/errors_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Yoti::Sandbox::DocScan::Error' do
+  let(:some_error_message) { 'SOME_ERROR_MESSAGE' }
+  let(:some_code) { 'SOME_CODE' }
+  let(:some_message) { 'SOME_MESSAGE' }
+  let(:some_property) { 'SOME_PROPERTY' }
+  let(:some_property_message) { 'SOME_PROPERTY_MESSAGE' }
+  let(:some_other_property) { 'SOME_OTHER_PROPERTY' }
+  let(:some_other_property_message) { 'SOME_OTHER_PROPERTY_MESSAGE' }
+  let(:some_response) { instance_double(Net::HTTPResponse, body: response_body, :[] => 'application/json') }
+  let(:some_request_error) do
+    Yoti::RequestError.new(some_error_message, some_response)
+  end
+
+  context 'when created with message' do
+    let(:error) do
+      Yoti::Sandbox::DocScan::Error.new(some_error_message)
+    end
+
+    it 'uses provided error message' do
+      expect(error.message).to eql(some_error_message)
+    end
+
+    it 'is a Yoti::RequestError' do
+      expect(error).to be_a(Yoti::RequestError)
+    end
+  end
+
+  context 'when created with message and response' do
+    let(:error) do
+      Yoti::Sandbox::DocScan::Error.new(some_error_message, some_response)
+    end
+    let(:response_body) { { code: some_code, message: some_message }.to_json }
+
+    it 'uses formatted response' do
+      expect(error.message).to eql("#{some_code} - #{some_message}")
+    end
+  end
+
+  context 'when wrapped error response has code and message' do
+    let(:error) do
+      Yoti::Sandbox::DocScan::Error.wrap(some_request_error)
+    end
+    let(:response_body) { { code: some_code, message: some_message }.to_json }
+
+    it 'includes code and message in error message' do
+      expect(error.message).to eql("#{some_code} - #{some_message}")
+    end
+  end
+
+  context 'when wrapped error response has code, message and errors' do
+    let(:error) do
+      Yoti::Sandbox::DocScan::Error.wrap(some_request_error)
+    end
+    let(:response_body) do
+      {
+        code: some_code,
+        message: some_message,
+        errors: [
+          {
+            property: some_property,
+            message: some_property_message
+          },
+          {
+            property: some_other_property,
+            message: some_other_property_message
+          }
+        ]
+      }.to_json
+    end
+
+    it 'includes code, message and errors in error message' do
+      error.message
+      error.message
+      expect(error.message)
+        .to eql("#{some_code} - #{some_message}: #{some_property} \"#{some_property_message}\", #{some_other_property} \"#{some_other_property_message}\"")
+    end
+  end
+
+  context 'when wrapped error response has no code or message' do
+    let(:error) do
+      Yoti::Sandbox::DocScan::Error.wrap(some_request_error)
+    end
+    let(:response_body) { { some: 'json' }.to_json }
+
+    it 'uses wrapped error message with response' do
+      expect(error.message).to eql("#{some_error_message}: #{response_body}")
+    end
+  end
+
+  context 'when wrapped error response is not available' do
+    let(:error) do
+      Yoti::Sandbox::DocScan::Error.wrap(some_request_error)
+    end
+    let(:some_response) { nil }
+
+    it 'uses wrapped error message' do
+      expect(error.message).to eql(some_error_message)
+    end
+  end
+end


### PR DESCRIPTION
### Changed
- `Yoti::Sandbox::DocScan::Client` calls now raises `Yoti::Sandbox::DocScan::Error < RequestError` with formatted error response (was `RequestError` with JSON response)
  > Note: `rescue Yoti::RequestError` will continue to work as before

#### Notes
- Follows same format as https://github.com/getyoti/yoti-ruby-sdk/pull/118
- `Yoti::Sandbox::DocScan::Error` doesn't extend `Yoti::DocScan::Error` as the services are separate