### PR TITLE
SDK-1765: Exclude document fields from JSON when not set

### DIFF
--- a/lib/yoti_sandbox/doc_scan/request/check/document_text_data_check.rb
+++ b/lib/yoti_sandbox/doc_scan/request/check/document_text_data_check.rb
@@ -18,13 +18,15 @@ module Yoti
         class DocumentTextDataCheckResult < CheckResult
           #
           # @param [CheckReport] report
-          # @param [Hash] document_fields
+          # @param [Hash,nil] document_fields
           #
           def initialize(report, document_fields)
             super(report)
 
-            Validation.assert_is_a(Hash, document_fields, 'document_fields')
-            document_fields.each { |_k, v| Validation.assert_respond_to(:to_json, v, 'document_fields value') }
+            unless document_fields.nil?
+              Validation.assert_is_a(Hash, document_fields, 'document_fields')
+              document_fields.each { |_k, v| Validation.assert_respond_to(:to_json, v, 'document_fields value') }
+            end
             @document_fields = document_fields
           end
 
@@ -36,12 +38,6 @@ module Yoti
         end
 
         class DocumentTextDataCheckBuilder < DocumentCheckBuilder
-          def initialize
-            super
-
-            @document_fields = {}
-          end
-
           #
           # @param [String] key
           # @param [#to_json] value
@@ -51,6 +47,7 @@ module Yoti
           def with_document_field(key, value)
             Validation.assert_is_a(String, key, 'key')
             Validation.assert_respond_to(:to_json, value, 'value')
+            @document_fields ||= {}
             @document_fields[key] = value
             self
           end

--- a/lib/yoti_sandbox/doc_scan/request/task/document_text_data_extraction_task.rb
+++ b/lib/yoti_sandbox/doc_scan/request/task/document_text_data_extraction_task.rb
@@ -43,11 +43,13 @@ module Yoti
 
         class DocumentTextDataExtractionTaskResult
           #
-          # @param [Hash] document_fields
+          # @param [Hash,nil] document_fields
           #
           def initialize(document_fields)
-            Validation.assert_is_a(Hash, document_fields, 'document_fields')
-            document_fields.each { |_k, v| Validation.assert_respond_to(:to_json, v, 'document_fields value') }
+            unless document_fields.nil?
+              Validation.assert_is_a(Hash, document_fields, 'document_fields')
+              document_fields.each { |_k, v| Validation.assert_respond_to(:to_json, v, 'document_fields value') }
+            end
             @document_fields = document_fields
           end
 
@@ -58,15 +60,11 @@ module Yoti
           def as_json(*_args)
             {
               document_fields: @document_fields
-            }
+            }.compact
           end
         end
 
         class DocumentTextDataExtractionTaskBuilder
-          def initialize
-            @document_fields = {}
-          end
-
           #
           # @param [String] key
           # @param [#to_json] value
@@ -76,6 +74,7 @@ module Yoti
           def with_document_field(key, value)
             Validation.assert_is_a(String, key, 'key')
             Validation.assert_respond_to(:to_json, value, 'value')
+            @document_fields ||= {}
             @document_fields[key] = value
             self
           end

--- a/spec/yoti_sandbox/doc_scan/request/check/document_text_data_check_spec.rb
+++ b/spec/yoti_sandbox/doc_scan/request/check/document_text_data_check_spec.rb
@@ -41,8 +41,7 @@ describe 'Yoti::Sandbox::DocScan::Request::DocumentTextDataCheck' do
           'report' => {
             'recommendation' => some_recommendation.as_json,
             'breakdown' => [some_breakdown.as_json]
-          },
-          'document_fields' => {}
+          }
         },
         'document_filter' => some_filter.as_json
       }
@@ -142,8 +141,7 @@ describe 'Yoti::Sandbox::DocScan::Request::DocumentTextDataCheck' do
               some_breakdown.as_json,
               some_other_breakdown.as_json
             ]
-          },
-          'document_fields' => {}
+          }
         }
       }
 

--- a/spec/yoti_sandbox/doc_scan/request/task/document_text_data_extraction_task_spec.rb
+++ b/spec/yoti_sandbox/doc_scan/request/task/document_text_data_extraction_task_spec.rb
@@ -20,9 +20,7 @@ describe 'Yoti::Sandbox::DocScan::Request::DocumentTextDataExtractionTask' do
 
     it 'serializes with document filter' do
       expected = {
-        'result' => {
-          'document_fields' => {}
-        },
+        'result' => {},
         'document_filter' => some_filter.as_json
       }
 


### PR DESCRIPTION
### Fixed
- Document fields are excluded from JSON when not set